### PR TITLE
fix: use common python3 binary path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON ?= python
+PYTHON ?= python3
 
 clean:
 	$(PYTHON) setup.py clean

--- a/git-remote-rclone
+++ b/git-remote-rclone
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.11
+#!/usr/bin/env python3
 
 import json
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 from setuptools import setup
 


### PR DESCRIPTION
This commit fixes the hardcoded python version.
On systems without python3.11 the script would otherwise fail.

Tested against python 3.7, 3.12, 3.13 and 3.14 and it works